### PR TITLE
Fix warnings on iOS 9

### DIFF
--- a/VPInteractiveImageViewController/VPInteractiveImageViewController.xcodeproj/project.pbxproj
+++ b/VPInteractiveImageViewController/VPInteractiveImageViewController.xcodeproj/project.pbxproj
@@ -242,7 +242,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = VP;
-				LastUpgradeCheck = 0500;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Vidu Pirathaparajah";
 				TargetAttributes = {
 					12375E801896FFD300279949 = {
@@ -349,7 +349,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -364,6 +363,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -389,7 +389,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -428,6 +427,7 @@
 				GCC_PREFIX_HEADER = "VPInteractiveImageViewController/VPInteractiveImageViewController-Prefix.pch";
 				INFOPLIST_FILE = "VPInteractiveImageViewController/VPInteractiveImageViewController-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.vidup.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -442,6 +442,7 @@
 				GCC_PREFIX_HEADER = "VPInteractiveImageViewController/VPInteractiveImageViewController-Prefix.pch";
 				INFOPLIST_FILE = "VPInteractiveImageViewController/VPInteractiveImageViewController-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.vidup.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -450,7 +451,6 @@
 		12375E961896FFD400279949 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/VPInteractiveImageViewController.app/VPInteractiveImageViewController";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
@@ -464,6 +464,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = "VPInteractiveImageViewControllerTests/VPInteractiveImageViewControllerTests-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.vidup.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";
 				WRAPPER_EXTENSION = xctest;
@@ -473,7 +474,6 @@
 		12375E971896FFD400279949 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/VPInteractiveImageViewController.app/VPInteractiveImageViewController";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
@@ -483,6 +483,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "VPInteractiveImageViewController/VPInteractiveImageViewController-Prefix.pch";
 				INFOPLIST_FILE = "VPInteractiveImageViewControllerTests/VPInteractiveImageViewControllerTests-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.vidup.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";
 				WRAPPER_EXTENSION = xctest;

--- a/VPInteractiveImageViewController/VPInteractiveImageViewController/Example/VPExampleViewController.m
+++ b/VPInteractiveImageViewController/VPInteractiveImageViewController/Example/VPExampleViewController.m
@@ -52,7 +52,12 @@
     return cell;
 }
 
+// switch can be removed when we switch to iOS 9 and Xcode 7 fully
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 90000
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
+#else
 - (NSUInteger)supportedInterfaceOrientations {
+#endif
     return UIInterfaceOrientationMaskPortrait;
 }
 

--- a/VPInteractiveImageViewController/VPInteractiveImageViewController/VPInteractiveImageViewController-Info.plist
+++ b/VPInteractiveImageViewController/VPInteractiveImageViewController/VPInteractiveImageViewController-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.vidup.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/VPInteractiveImageViewController/VPInteractiveImageViewController/VPInteractiveImageViewController.h
+++ b/VPInteractiveImageViewController/VPInteractiveImageViewController/VPInteractiveImageViewController.h
@@ -16,5 +16,6 @@
 - (instancetype)initWithInteractiveImageView:(VPInteractiveImageView *)interactiveImageView NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil NS_UNAVAILABLE;
 - (instancetype)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 
 @end

--- a/VPInteractiveImageViewController/VPInteractiveImageViewController/VPInteractiveImageViewController.h
+++ b/VPInteractiveImageViewController/VPInteractiveImageViewController/VPInteractiveImageViewController.h
@@ -14,5 +14,7 @@
 @property (nonatomic, readonly) UIImageView *imageView;
 
 - (instancetype)initWithInteractiveImageView:(VPInteractiveImageView *)interactiveImageView NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil NS_UNAVAILABLE;
+- (instancetype)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
 
 @end

--- a/VPInteractiveImageViewController/VPInteractiveImageViewController/VPInteractiveImageViewController.m
+++ b/VPInteractiveImageViewController/VPInteractiveImageViewController/VPInteractiveImageViewController.m
@@ -19,8 +19,10 @@
 
 @implementation VPInteractiveImageViewController
 
+#pragma mark - Initializers
+
 - (instancetype)initWithInteractiveImageView:(VPInteractiveImageView *)interactiveImageView {
-    self = [super init];
+    self = [super initWithNibName:nil bundle:nil];
     if (self) {
         _imageView = [[UIImageView alloc] initWithFrame:CGRectZero];
         _imageView.contentMode = UIViewContentModeScaleAspectFit;
@@ -28,6 +30,17 @@
         _interactiveImageView = interactiveImageView;
     }
     return self;
+}
+
+- (instancetype)initWithNibName:(nullable NSString *)nibNameOrNil
+                         bundle:(nullable NSBundle *)nibBundleOrNil {
+    self = [self initWithInteractiveImageView:nil];
+    @throw [NSException exceptionWithName:@"wrong init" reason:nil userInfo:nil];
+}
+
+- (instancetype)initWithCoder:(nonnull NSCoder *)aDecoder {
+    self = [self initWithInteractiveImageView:nil];
+    @throw [NSException exceptionWithName:@"wrong init" reason:nil userInfo:nil];
 }
 
 - (void)dealloc {

--- a/VPInteractiveImageViewController/VPInteractiveImageViewControllerTests/VPInteractiveImageViewControllerTests-Info.plist
+++ b/VPInteractiveImageViewController/VPInteractiveImageViewControllerTests/VPInteractiveImageViewControllerTests-Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.vidup.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>


### PR DESCRIPTION
This makes all warnings go away in iOS 9 and iOS 8