### PR TITLE
Fixed orientation issues.

### DIFF
--- a/VPInteractiveImageViewController/VPInteractiveImageViewController/Example/VPExampleViewController.m
+++ b/VPInteractiveImageViewController/VPInteractiveImageViewController/Example/VPExampleViewController.m
@@ -52,15 +52,6 @@
     return cell;
 }
 
-// switch can be removed when we switch to iOS 9 and Xcode 7 fully
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 90000
-- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
-#else
-- (NSUInteger)supportedInterfaceOrientations {
-#endif
-    return UIInterfaceOrientationMaskPortrait;
-}
-
 #pragma mark - VPInteractiveImageViewDelegate
 
 - (void)interactiveImageViewWillPresent:(VPInteractiveImageView *)imageView {

--- a/VPInteractiveImageViewController/VPInteractiveImageViewController/VPTransitionAnimator.m
+++ b/VPInteractiveImageViewController/VPInteractiveImageViewController/VPTransitionAnimator.m
@@ -62,7 +62,6 @@
                                          fromView:self.interactiveImageView.superview];
     CGRect finalImageViewRect = self.imageView.frame;
     self.imageView.frame = self.originFrame;
-    self.imageView.transform = [self affineTransformForInterfaceOrientation:toViewController.interfaceOrientation];
     toViewController.view.frame = endFrame;
     toViewController.view.backgroundColor = [UIColor clearColor];
 
@@ -98,8 +97,6 @@
 
     [UIView animateWithDuration:[self transitionDuration:transitionContext]
                      animations:^{
-//                         fromViewController.view.frame = self.originFrame;
-                         self.imageView.transform = [self affineTransformForInterfaceOrientation:fromViewController.interfaceOrientation];
                          self.imageView.frame = [fromViewController.view convertRect:self.originFrame fromView:containerView];
                          fromViewController.view.layer.backgroundColor = 0;
                      } completion:^(BOOL finished) {
@@ -108,23 +105,4 @@
     }];
 }
 
-
-- (CGAffineTransform)affineTransformForInterfaceOrientation:(UIInterfaceOrientation)orientation {
-    CGFloat angle;
-    switch (orientation) {
-        case UIInterfaceOrientationPortraitUpsideDown:
-            angle = M_PI;
-            break;
-        case UIInterfaceOrientationLandscapeLeft:
-            angle = M_PI_2;
-            break;
-        case UIInterfaceOrientationLandscapeRight:
-            angle = -M_PI_2;
-            break;
-        default:
-            angle = 0;
-            break;
-    }
-    return CGAffineTransformMakeRotation(angle);
-}
 @end


### PR DESCRIPTION
There was no need to manually calculate the transformation of the image view based on the device orientation anymore. The VC can handle this by itself. This PR fixes the orientation issued that occurred. The example has been updated.
